### PR TITLE
Update raml-tester to 0.9.1 and support x-www-form-urlencode content

### DIFF
--- a/commons-rest-test/pom.xml
+++ b/commons-rest-test/pom.xml
@@ -57,7 +57,8 @@
         <dependency>
             <groupId>guru.nidi.raml</groupId>
             <artifactId>raml-tester</artifactId>
-            <version>0.8.9</version>
+            <!-- Partially supports RAML 1.0 -->
+            <version>0.9.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/commons-rest-test/src/main/java/com/mule/connectors/commons/rest/test/assertion/raml/ValidRaml.java
+++ b/commons-rest-test/src/main/java/com/mule/connectors/commons/rest/test/assertion/raml/ValidRaml.java
@@ -8,6 +8,7 @@ import com.mule.connectors.commons.rest.test.assertion.RequestAndResponseAsserti
 import guru.nidi.ramltester.RamlDefinition;
 import guru.nidi.ramltester.RamlLoaders;
 import guru.nidi.ramltester.core.RamlReport;
+import guru.nidi.ramltester.core.RamlViolationMessage;
 import guru.nidi.ramltester.core.RamlViolations;
 import guru.nidi.ramltester.core.Validation;
 import org.hamcrest.BaseMatcher;
@@ -52,9 +53,9 @@ public class ValidRaml extends BaseMatcher<RequestAndResponse> implements Reques
     }
 
     private void addErrors(Description description, RamlViolations errors) {
-        for (String error : errors) {
+        for (RamlViolationMessage error : errors) {
             description.appendText("\n\t\t");
-            description.appendText(error);
+            description.appendText(error.getMessage());
         }
     }
 

--- a/commons-rest/src/main/java/com/mule/connectors/commons/rest/builder/request/SimpleRequest.java
+++ b/commons-rest/src/main/java/com/mule/connectors/commons/rest/builder/request/SimpleRequest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
 import static javax.ws.rs.core.MediaType.APPLICATION_XML;
+import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA;
 
 public class SimpleRequest implements Request {
     private static final Logger logger = LoggerFactory.getLogger(SimpleRequest.class);
@@ -55,11 +56,11 @@ public class SimpleRequest implements Request {
             logger.debug("Header: '{}': {}", entry.getKey(), entry.getValue());
         }
 
-        Object entity = Optional.fromNullable(getEntity()).or(new Form());
-        // Support for application/x-www-form-urlencoded
-        // Body must a Form object instead of default LinkedHashMap so as to be picked by the FormProvider (not JacksonJaxbJsonProvider)
-        setEntity(getContentType().equals(APPLICATION_FORM_URLENCODED) && Optional.of(entity).isPresent() ?
-                new Form(new MultivaluedHashMap((LinkedHashMap<String, Object>) getEntity())) : entity);
+        // FIXME: this is mostly a workaround and should be improved.
+        // Support for body form parameters
+        // Body must be a Form object instead of default LinkedHashMap so as to be picked by the FormProvider (not JacksonJaxbJsonProvider)
+        setEntity((getContentType().equals(APPLICATION_FORM_URLENCODED) || getContentType().equals(MULTIPART_FORM_DATA))
+                && (Optional.fromNullable(getEntity())).isPresent() ? new Form(new MultivaluedHashMap((LinkedHashMap<String, Object>) getEntity())) : new Form());
 
         // Executing the request.
         Response response = getMethod().execute(requestBuilder, getEntity(), getContentType());


### PR DESCRIPTION
I added a fix for body of type `application/x-www-form-urlencoded`, to overcome the following exception:

```
org.glassfish.jersey.message.internal.MessageBodyProviderNotFoundException: MessageBodyWriter not found for media type=application/x-www-form-urlencoded, type=class java.util.LinkedHashMap, genericType=class java.util.LinkedHashMap.
```